### PR TITLE
Convert to Go integers where applicable.

### DIFF
--- a/gluamapper.go
+++ b/gluamapper.go
@@ -86,6 +86,9 @@ func ToGoValue(lv lua.LValue, opt Option) interface{} {
 	case lua.LString:
 		return string(v)
 	case lua.LNumber:
+		if float64(int(v)) == float64(v) {
+	    	return int(v)
+		}
 		return float64(v)
 	case *lua.LTable:
 		maxn := v.MaxN()


### PR DESCRIPTION
Title really says it all.

Noticed the lack of this when using gluamapper to convert to something other than JSON.  It'll still work fine for JSON since Go's JSON package knows how to serialize an Int.